### PR TITLE
Update Content-Security-Policy in vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -11,7 +11,7 @@
       "headers": [
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; style-src 'self' https://fonts.cdnfonts.com; font-src 'self' https://fonts.cdnfonts.com; connect-src 'self' https://dnyoewdnwjkprcaebtyh.supabase.co https://api.mirahub.me; img-src 'self' data:; frame-ancestors 'none';"
+          "value": "default-src 'self'; style-src 'self' https://fonts.cdnfonts.com 'unsafe-inline'; font-src 'self' https://fonts.cdnfonts.com; connect-src 'self' https://dnyoewdnwjkprcaebtyh.supabase.co https://api.mirahub.me; img-src 'self' data: https://dnyoewdnwjkprcaebtyh.supabase.co; frame-ancestors 'none';"
         },
         {
           "key": "X-Content-Type-Options",

--- a/vercel.json
+++ b/vercel.json
@@ -11,7 +11,7 @@
       "headers": [
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; style-src 'self' https://fonts.cdnfonts.com; font-src 'self' https://fonts.cdnfonts.com; connect-src 'self' https://dnyoewdnwjkprcaebtyh.supabase.co https://api.mirahub.me;"
+          "value": "default-src 'self'; style-src 'self' https://fonts.cdnfonts.com; font-src 'self' https://fonts.cdnfonts.com; connect-src 'self' https://dnyoewdnwjkprcaebtyh.supabase.co https://api.mirahub.me; img-src 'self' data:; frame-ancestors 'none';"
         },
         {
           "key": "X-Content-Type-Options",
@@ -24,6 +24,10 @@
         {
           "key": "Cross-Origin-Resource-Policy",
           "value": "same-origin"
+        },
+        {
+          "key": "Referrer-Policy",
+          "value": "strict-origin-when-cross-origin"
         }
       ]
     }


### PR DESCRIPTION
Enhance the Content-Security-Policy by adding directives for img-src and frame-ancestors, and allow 'unsafe-inline' for style-src to improve styling flexibility.