### PR TITLE
Add Cache-Control header for index.html

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -7,6 +7,15 @@
   ],
   "headers": [
     {
+      "source": "/index.html",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "no-store"
+        }
+      ]
+    },
+    {
       "source": "/(.*)",
       "headers": [
         {


### PR DESCRIPTION
Introduce a Cache-Control header to index.html to prevent caching and ensure fresh content delivery.